### PR TITLE
fix arg bugs

### DIFF
--- a/neuzz.c
+++ b/neuzz.c
@@ -1817,8 +1817,8 @@ void copy_seeds(char * in_dir, char * out_dir){
     while((de = readdir(dp)) != NULL){ 
          if(strcmp(".",de->d_name) == 0 || strcmp("..",de->d_name) == 0)
             continue;
-        sprintf(src, "%s%s", in_dir, de->d_name);
-        sprintf(dst, "%s%s", out_dir, de->d_name);
+        sprintf(src, "%s/%s", in_dir, de->d_name);
+        sprintf(dst, "%s/%s", out_dir, de->d_name);
         copy_file(src, dst);
     }
     closedir(dp);

--- a/nn.py
+++ b/nn.py
@@ -33,7 +33,7 @@ seed_list = glob.glob('./seeds/*')
 new_seeds = glob.glob('./seeds/id_*')
 SPLIT_RATIO = len(seed_list)
 # get binary argv
-argvv = sys.argv.pop(0)
+argvv = sys.argv[1:]
 
 # process training data from afl raw data
 def process_data():


### PR DESCRIPTION
When run ``python nn.py ./readelf -a``, sys.argv will be ``['nn.py', './readelf', '-a']``, and ``sys.argv.pop(0)`` will be ``nn.py``, this could trigger an error.

Apart from this, ``neuzz`` use ``neuzz_in`` and ``seeds`` as input, but do not have directory separator in ``copy_seeds``.